### PR TITLE
🚑 fix: 메시지가 포함되는 응답에서 벡터 정보 삭제

### DIFF
--- a/app/routes/message.py
+++ b/app/routes/message.py
@@ -52,6 +52,10 @@ class UserMessages(Resource):
     def get(self, user_id):
         """특정 사용자의 모든 메시지 기록을 가져옵니다."""
         try:
-            return message_service.get_user_messages(user_id)
+            messages = []
+            for message in message_service.get_user_messages(user_id):
+                del message['vector']
+                messages.append(message)
+            return messages, 200
         except Exception as e:
             return {'error': str(e)}, 400

--- a/app/routes/session.py
+++ b/app/routes/session.py
@@ -348,7 +348,11 @@ class SessionMessages(Resource):
     def get(self, session_id):
         """특정 세션의 모든 메시지 기록을 가져옵니다."""
         try:
-            messages = message_service.get_session_messages(session_id)
-            return messages
+            messages = []
+            for message in message_service.get_session_messages(session_id):
+                del message['vector']
+                messages.append(message)
+            return messages, 200
         except Exception as e:
+            print(e)
             ns.abort(400, f"Failed to get session messages: {str(e)}")


### PR DESCRIPTION
## 📝 PR 설명
<!-- PR에 대한 간단한 설명을 작성해주세요 -->
네트워크를 통해 전달되는 데이터 양이 너무 많아서 프론트엔드에서 실제로 값을 조회할 수 없습니다. 이에 메시지를 응답할 때는 벡터 정보는 제외하고 응답하도록 수정했습니다.

## 🔍 변경사항
<!-- 주요 변경사항을 bullet point로 작성해주세요 -->
- 요청의 응답에서 메시지 내의 벡터 속성 제거
  - `s/{user-id}/m` 
  - `m/{user-id}`

## 🧪 테스트
<!-- 테스트 방법과 결과를 작성해주세요. 테스트 작성이 필요 없다면 전부 체크해주세요 -->
- [ ] 새로 추가한 기능의 테스트 코드를 작성했나요?
- [ ] 작성한 테스트 코드가 GitHub Actions에서 실행되나요?
- [ ] 작성한 테스트 코드가 실행되면 오류가 발생하지 않았나요?
- [x] 테스트 코드 작성이 힘들다면 [@GideokKim](https://github.com/GideokKim)에게 문의해주세요.

## ✅ 체크리스트
<!-- PR을 제출하기 전에 다음 사항들을 확인해주세요 -->
- [x] 불필요한 주석이나 디버그 코드를 제거했나요?
- [x] 관련 문서를 업데이트했나요? (README.md, API 문서 등)
- [x] 환경 변수나 설정 파일이 변경되었다면, 팀원들과 공유했나요?
- [x] 커밋 메시지가 명확하고 이해하기 쉬운가요?


## 📌 추가 참고사항
<!-- PR과 관련하여 추가로 공유하고 싶은 내용이 있다면 작성해주세요 --> 
@GideokKim 테스트가 필요하지만 하는 법을 모르겠습니다...